### PR TITLE
upgrade brave on launch

### DIFF
--- a/Singularity
+++ b/Singularity
@@ -17,5 +17,6 @@ rpm --import https://brave-browser-rpm-release.s3.brave.com/brave-core.asc
 dnf -y install brave-browser
 
 %runscript
+dnf -y upgrade brave-browser
 # --no-sandbox is a security risk
 brave-browser --no-sandbox "$@"


### PR DESCRIPTION
The image has a static version of Brave, but Brave is updated often, like once a week.

Would this keep Brave up to date? In general, I only relaunch Brave when there is an update, so there is no drawback for me to turn this around and update Brave every time it is launched.

See option nr. 2 in #1.